### PR TITLE
feat: 전역 예외 처리 구현 및 기본 에러코드 처리 완성

### DIFF
--- a/src/main/java/com/example/demo/game/exception/GameErrorType.java
+++ b/src/main/java/com/example/demo/game/exception/GameErrorType.java
@@ -1,0 +1,18 @@
+package com.example.demo.game.exception;
+
+import com.example.demo.global.exception.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GameErrorType implements ErrorType {
+
+    GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 게임을 찾을 수 없습니다."),
+    INVALID_CONTENT_NUM(HttpStatus.BAD_REQUEST, "유효하지 않은 content_num입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/demo/game/exception/GameException.java
+++ b/src/main/java/com/example/demo/game/exception/GameException.java
@@ -1,0 +1,15 @@
+package com.example.demo.game.exception;
+
+import com.example.demo.global.exception.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class GameException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    public GameException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+}

--- a/src/main/java/com/example/demo/game/service/GameService.java
+++ b/src/main/java/com/example/demo/game/service/GameService.java
@@ -1,8 +1,9 @@
-// 3. Service
 package com.example.demo.game.service;
 
 import com.example.demo.game.dto.GameDto;
 import com.example.demo.game.entity.Game;
+import com.example.demo.game.exception.GameErrorType;
+import com.example.demo.game.exception.GameException;
 import com.example.demo.game.repository.GameRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class GameService {
     // ID로 단건 조회
     public GameDto.GameResponse getGameById(Long id) {
         Game game = gameRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("게임을 찾을 수 없습니다: " + id));
+            .orElseThrow(() -> new GameException(GameErrorType.GAME_NOT_FOUND));
         return GameDto.GameResponse.from(game);
     }
 

--- a/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.example.demo.global.exception;
 
+import com.example.demo.game.exception.GameException;
 import com.example.demo.global.response.ApiResponse;
+import com.example.demo.job.exception.JobException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +27,32 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CoreException.class)
     public ResponseEntity<ApiResponse<?>> handleCoreException(CoreException e) {
         log.warn("CoreException: {}", e.getMessage());
+        ErrorType errorType = e.getErrorType();
+        return ResponseEntity
+                .status(errorType.getStatus())
+                .body(ApiResponse.error(errorType));
+    }
+
+    /**
+     * JobException 처리
+     * Job 관련 비즈니스 로직 예외
+     */
+    @ExceptionHandler(JobException.class)
+    public ResponseEntity<ApiResponse<?>> handleJobException(JobException e) {
+        log.warn("JobException: {}", e.getMessage());
+        ErrorType errorType = e.getErrorType();
+        return ResponseEntity
+                .status(errorType.getStatus())
+                .body(ApiResponse.error(errorType));
+    }
+
+    /**
+     * GameException 처리
+     * Game 관련 비즈니스 로직 예외
+     */
+    @ExceptionHandler(GameException.class)
+    public ResponseEntity<ApiResponse<?>> handleGameException(GameException e) {
+        log.warn("GameException: {}", e.getMessage());
         ErrorType errorType = e.getErrorType();
         return ResponseEntity
                 .status(errorType.getStatus())


### PR DESCRIPTION
- GameException 및 GameErrorType 추가
- GlobalExceptionHandler에 JobException, GameException 핸들러 추가
- GameService의 예외 처리를 GameException으로 통일
- 400, 404, 500 에러에 대한 전역 예외 처리 완성

예외 처리 기능:
- 400 Bad Request: 입력값 검증 실패, 파라미터 누락, 타입 불일치 등
- 404 Not Found: Job/Game 리소스를 찾을 수 없음
- 500 Internal Server Error: 예상치 못한 서버 오류

테스트 방법:
- 400: 잘못된 입력값으로 POST /api/job 호출
- 404: 존재하지 않는 ID로 GET /api/job/detail?jobId=999999 호출
- 500: 서버 내부 오류 발생 시 자동 처리